### PR TITLE
Fix for inclusion of feature model into graph writing

### DIFF
--- a/Frontend/src/main/scala/de/fosd/typechef/Frontend.scala
+++ b/Frontend/src/main/scala/de/fosd/typechef/Frontend.scala
@@ -198,7 +198,7 @@ object Frontend extends EnforceTreeHelper {
                     c.writeDotCallGraph(opt.getFile, dotWriter /*, fullFM */) /* if no feature model is provided, an empty one is used */
 
                     // DEBUG
-                     c.writeDbgCallGraph(opt.getFile, dbgWriter /*, fullFM */) /* if no feature model is provided, an empty one is used */
+                     c.writeDbgCallGraph(opt.getFile, dbgWriter, fullFM) /* if no feature model is provided, an empty one is used */
                     // c.showPointerEquivalenceClasses()
                     // c.showFunctionDefs()
                     // c.showFunctionCalls()

--- a/Frontend/src/main/scala/de/fosd/typechef/Frontend.scala
+++ b/Frontend/src/main/scala/de/fosd/typechef/Frontend.scala
@@ -195,7 +195,7 @@ object Frontend extends EnforceTreeHelper {
                     c.showCallGraphStatistics()
 
                     // Dot Call Graph
-                    c.writeDotCallGraph(opt.getFile, dotWriter /*, fullFM */) /* if no feature model is provided, an empty one is used */
+                    c.writeDotCallGraph(opt.getFile, dotWriter, fullFM) /* if no feature model is provided, an empty one is used */
 
                     // DEBUG
                      c.writeDbgCallGraph(opt.getFile, dbgWriter, fullFM) /* if no feature model is provided, an empty one is used */

--- a/Frontend/src/main/scala/de/fosd/typechef/Frontend.scala
+++ b/Frontend/src/main/scala/de/fosd/typechef/Frontend.scala
@@ -191,7 +191,7 @@ object Frontend extends EnforceTreeHelper {
                     val c = new CCallGraph()
                     c.calculatePointerEquivalenceRelation(ast)
                     c.extractCallGraph()
-                    c.writeCallGraph(opt.getFile, writer /*, fullFM */) /* if no feature model is provided, an empty one is used */
+                    c.writeCallGraph(opt.getFile, writer, fullFM) /* if no feature model is provided, an empty one is used */
                     c.showCallGraphStatistics()
 
                     // Dot Call Graph


### PR DESCRIPTION
The feature model is loaded in line 102 of Frontend.scala. The default fallback for this is the empty feature model, if none is provided via command-line parameter. Thus, we can include the feature model into the graph-writing utility by default.
